### PR TITLE
[fix/#5 userDashboard] 일정 결재 상신 날짜 로직 수정 

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/sysone/ogamza/controller/user/ScheduleRegisterController.java
+++ b/src/main/java/com/sysone/ogamza/controller/user/ScheduleRegisterController.java
@@ -13,8 +13,6 @@ import javafx.scene.control.DatePicker;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 
-import java.time.DateTimeException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -70,12 +68,13 @@ public class ScheduleRegisterController {
         for (ScheduleListDTO dto : list) {
             LocalDateTime startDate = dto.getStartDate();
             LocalDateTime endDate = dto.getEndDate();
+            int isGranted = dto.getIsGranted();
 
             LocalDateTime newStart = startDatePicker.getValue().atStartOfDay();
             LocalDateTime newEnd = endDatePicker.getValue().atStartOfDay();
 
             boolean isOverlapping = !(newEnd.isBefore(startDate) || newStart.isAfter(endDate));
-            if (isOverlapping) {
+            if (isOverlapping && (isGranted == 0 || isGranted == 1)) {
                 AlertCreate.showAlert(Alert.AlertType.ERROR, "결재 상신", "기존 일정과 겹치는 기간이 있습니다.");
                 return;
             }

--- a/src/main/java/com/sysone/ogamza/service/user/DashboardService.java
+++ b/src/main/java/com/sysone/ogamza/service/user/DashboardService.java
@@ -78,12 +78,10 @@ public class DashboardService {
         int today = LocalDateTime.now().getDayOfMonth();
         LocalDateTime currentTime = (leaveTime.getDayOfMonth() == today) ? LocalDateTime.now() : leaveTime;
 
-        currentTime = LocalDateTime.of(2025, 7, 25, 15, 0);
         Duration duration = Duration.between(accessTime, currentTime);
 
         long hours = duration.toHours();
         long minutes = duration.toMinutes();
-        System.out.println(minutes);
 
         String worked = (minutes % 60 == 0) ? (hours != 0) ? (hours) + "시간" : "0시간" : (hours != 0) ? (hours) + "시간 " + (minutes % 60) + "분" : "0시간 " + (minutes % 60) + "분";
         String remaining = (hours >= 9) ? "0시간 0분" : (minutes !=  0) ? (hours != 0) ? (8 - hours) + "시간 " + (60 - ((minutes % 60))) + "분" : "7시간 " + (60 - ((minutes % 60))) + "분" : "8시간 0분";


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 

## 📝작업 내용

> 일정 결재 상신 시 일정 겹침 로직을 기존에는 상신 취소 된 것도 적용되었는데
> 해당 부분 상신 대기, 상신 완료 된 것만 일정 겹침으로 로직 수정


### 🖼️ 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

